### PR TITLE
POM Update

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+.classpath
+.project
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>19-SNAPSHOT</version>
+    <version>22-SNAPSHOT</version>
   </parent>
 
   <groupId>org.mybatis.caches</groupId>
@@ -28,7 +29,7 @@
   <version>1.0.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <name>MyBatis Caches :: OSCache</name>
+  <name>mybatis-oscache</name>
   <description>OSCache support for MyBatis Cache</description>
   <url>http://www.mybatis.org/caches/oscache/</url>
 
@@ -66,7 +67,7 @@
     <dependency>
       <groupId>org.mybatis</groupId>
       <artifactId>mybatis</artifactId>
-      <version>3.2.2</version>
+      <version>3.2.7</version>
       <scope>provided</scope>
     </dependency>
 
@@ -76,7 +77,7 @@
     <dependency>
       <groupId>opensymphony</groupId>
       <artifactId>oscache</artifactId>
-      <version>2.4</version>
+      <version>2.4.1</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -118,7 +119,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.2</version>
+        <version>2.7</version>
         <reportSets>
           <reportSet>
             <reports>


### PR DESCRIPTION
Use mybatis-parent 22-SNAPSHOT
Switch <name> to match <artifactId> allowing import into myEclipse
properly
Updated mybatis to 3.2.7
Updated oscache to 2.4.1
Updated projects info reports to 2.7

Added gitattributes & gitignore
